### PR TITLE
Fix logging into parent directory

### DIFF
--- a/src/AbstractLogger.php
+++ b/src/AbstractLogger.php
@@ -54,9 +54,14 @@ abstract class AbstractLogger implements ILogger
 			$exception = $exception->getPrevious();
 		}
 		$hash = substr(md5(serialize($data)), 0, 10);
+		
+		/** @var \SplFileInfo $file */
 		foreach (new DirectoryIterator($this->directory) as $file) {
+			if ($file->isDot()) {
+				continue;
+			}
 			if (strpos($file, $hash)) {
-				return $this->directory . $file;
+				return $file->getPathname();
 			}
 		}
 


### PR DESCRIPTION
Hey.
There is a bug, when it creates log file in parent directory of `$this->directory`

- It will skip dot directories, you should ignore them
- Fix bug when `$this->directory` does not end with directory separator.

How to reproduce?:
1. Set your `logDir` for `TracyLogging` as `%appDir%/../log`
2. Set modo to production
3. Put somewhere in presenter action `throw new \Nette\InvalidArgumentException('TEST')`. 
4. On first throw .html will be in log directory, but second .html, of the same exception, will be in parent of log dir.